### PR TITLE
Replace usage of ?? operator with safe null check

### DIFF
--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/DraggedReferenceItem.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/DraggedReferenceItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -43,7 +43,7 @@ namespace RuntimeInspectorNamespace
 			if( canvas.renderMode == RenderMode.ScreenSpaceOverlay || ( canvas.renderMode == RenderMode.ScreenSpaceCamera && canvas.worldCamera == null ) )
 				worldCamera = null;
 			else
-				worldCamera = canvas.worldCamera ?? Camera.main;
+				worldCamera = canvas.worldCamera ? canvas.worldCamera : Camera.main;
 
 			if( skin != null )
 			{


### PR DESCRIPTION
The `??` operator performs reference comparisons and this can be [problematic](https://blogs.unity3d.com/2014/05/16/custom-operator-should-we-keep-it/) with `UnityEngine.Object`-derived objects which [compare](https://github.com/Unity-Technologies/UnityCsReference/blob/f78f4093c8a2b45949a847cdc704cf209dcf2f36/Runtime/Export/Scripting/UnityEngineObject.bindings.cs#L98) to null but aren't actually null references (eg. destroyed objects). 

Explicitly null-checking the `canvas.worldCamera` property correctly uses the overridden operator which in turn avoids a potential bug.