### PR TITLE
Fixed ArgumentOutOfRangeException when selecting ignored transform in editor

### DIFF
--- a/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
@@ -399,9 +399,8 @@ namespace RuntimeInspectorNamespace
 			if( !syncSelectionWithEditorHierarchy )
 				return;
 
-			Transform activeTransform = UnityEditor.Selection.activeTransform;
-			if( activeTransform && !RuntimeInspectorUtils.IsAnyParentIgnored( activeTransform ) )
-                Select( activeTransform );
+			if ( UnityEditor.Selection.activeTransform )
+				Select( UnityEditor.Selection.activeTransform );
 		}
 #endif
 

--- a/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
@@ -737,8 +737,6 @@ namespace RuntimeInspectorNamespace
 
 		public bool Select( Transform selection, bool forceSelection = false )
 		{
-
-
 			if( !selection )
 			{
 				Deselect();

--- a/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy.cs
@@ -399,8 +399,9 @@ namespace RuntimeInspectorNamespace
 			if( !syncSelectionWithEditorHierarchy )
 				return;
 
-			if( UnityEditor.Selection.activeTransform )
-				Select( UnityEditor.Selection.activeTransform );
+			Transform activeTransform = UnityEditor.Selection.activeTransform;
+			if( activeTransform && !RuntimeInspectorUtils.IsAnyParentIgnored( activeTransform ) )
+                Select( activeTransform );
 		}
 #endif
 
@@ -736,6 +737,8 @@ namespace RuntimeInspectorNamespace
 
 		public bool Select( Transform selection, bool forceSelection = false )
 		{
+
+
 			if( !selection )
 			{
 				Deselect();

--- a/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy/HierarchyData.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeHierarchy/HierarchyData.cs
@@ -213,6 +213,9 @@ namespace RuntimeInspectorNamespace
 
 		public HierarchyDataTransform FindTransform( Transform target, Transform nextInPath = null )
 		{
+			if ( m_depth < 0 ) // This object is hidden from Hierarchy
+				return null;
+
 			bool isInitSearch = nextInPath == null;
 			if( isInitSearch )
 			{

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
@@ -896,5 +896,16 @@ namespace RuntimeInspectorNamespace
 
 			return null;
 		}
+
+		public static bool IsAnyParentIgnored( Transform transform )
+        {
+            while( transform != null )
+            {
+				if( IgnoredTransformsInHierarchy.Contains( transform.parent ) )
+					return true;
+				transform = transform.parent;
+            }
+			return false;
+        }
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
@@ -896,16 +896,5 @@ namespace RuntimeInspectorNamespace
 
 			return null;
 		}
-
-		public static bool IsAnyParentIgnored( Transform transform )
-        {
-            while( transform != null )
-            {
-				if( IgnoredTransformsInHierarchy.Contains( transform.parent ) )
-					return true;
-				transform = transform.parent;
-            }
-			return false;
-        }
 	}
 }


### PR DESCRIPTION
How to reproduce the issue:

1. Add RuntimeHierarchy.prefab to a new scene
2. Enable Sync Selection With Editor Hierarchy option
3. In play mode, click any ignored item (or child of ignored item) in the Unity hierarchy, e.g. anything beneath RuntimeInspector/ScrollView/Viewport/Content

ArgumentOutOfRangeException is thrown in RuntimeHierarchy:250

This PR prevents ignored transforms and children of ignored transforms from being selected.