### PR TITLE
Added support for read-only fields

### DIFF
--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Attributes/RuntimeInspectorReadonlyAttribute.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Attributes/RuntimeInspectorReadonlyAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace RuntimeInspectorNamespace
+{
+	[AttributeUsage( AttributeTargets.Field, Inherited = false, AllowMultiple = false )]
+	public class RuntimeInspectorReadonlyAttribute : Attribute
+	{
+		private readonly InspectorField.IsReadonlyGetter m_getter = () => true;
+		public InspectorField.IsReadonlyGetter Getter { get { return m_getter; } }
+
+		public RuntimeInspectorReadonlyAttribute() {}
+
+		public RuntimeInspectorReadonlyAttribute( Type classAroundMethod, string methodName )
+		{
+			var getter = Delegate.CreateDelegate(
+				type: typeof( InspectorField.IsReadonlyGetter ),
+				target: classAroundMethod,
+				method: methodName,
+				ignoreCase: false,
+				throwOnBindFailure: false );
+
+			if( getter is InspectorField.IsReadonlyGetter readonlyGetter )
+				m_getter = readonlyGetter;
+		}
+	}
+}

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Attributes/RuntimeInspectorReadonlyAttribute.cs.meta
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Attributes/RuntimeInspectorReadonlyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3d52ae5f0b91624bbddc9b0d312b02f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ArrayField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ArrayField.cs
@@ -141,6 +141,7 @@ namespace RuntimeInspectorNamespace
 						( (ExpandableInspectorField) elementDrawer ).IsExpanded = true;
 
 					elementDrawer.NameRaw = Inspector.ArrayIndicesStartAtOne ? ( ( i + 1 ) + ":" ) : ( i + ":" );
+					elementDrawer.IsInteractable = IsInteractable;
 					elements.Add( elementDrawer );
 				}
 			}
@@ -165,6 +166,7 @@ namespace RuntimeInspectorNamespace
 					if( i < elementsExpandedStates.Count && elementsExpandedStates[i] && elementDrawer is ExpandableInspectorField )
 						( (ExpandableInspectorField) elementDrawer ).IsExpanded = true;
 
+					elementDrawer.IsInteractable = IsInteractable;
 					elements.Add( elementDrawer );
 				}
 			}
@@ -317,6 +319,14 @@ namespace RuntimeInspectorNamespace
 				template = elementType.Instantiate();
 
 			return template;
+		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			sizeInput.BackingField.interactable = IsInteractable;
+			sizeInput.BackingField.textComponent.color = this.GetTextColor();
+			sizeText.color = this.GetTextColor();
 		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/BoolField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/BoolField.cs
@@ -48,5 +48,12 @@ namespace RuntimeInspectorNamespace
 			base.Refresh();
 			input.isOn = (bool) Value;
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			input.interactable = IsInteractable;
+			input.graphic.color = this.GetTextColor();
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/BoundsField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/BoundsField.cs
@@ -86,6 +86,13 @@ namespace RuntimeInspectorNamespace
 			inputExtents.Depth = Depth + 1;
 		}
 
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			inputCenter.IsInteractable = IsInteractable;
+			inputExtents.IsInteractable = IsInteractable;
+		}
+
 		public override void Refresh()
 		{
 			base.Refresh();

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ColorField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ColorField.cs
@@ -40,6 +40,9 @@ namespace RuntimeInspectorNamespace
 
 		private void ShowColorPicker( PointerEventData eventData )
 		{
+			if( !IsInteractable )
+				return;
+
 			Color value = isColor32 ? (Color) (Color32) Value : (Color) Value;
 
 			ColorPicker.Instance.Skin = Inspector.Skin;

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/EnumField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/EnumField.cs
@@ -160,5 +160,13 @@ namespace RuntimeInspectorNamespace
 			if( valueIndex != -1 )
 				input.value = valueIndex;
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			input.interactable = IsInteractable;
+			input.captionText.color = this.GetTextColor();
+			dropdownArrow.color = this.GetTextColor();
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ExposedMethodField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ExposedMethodField.cs
@@ -35,6 +35,12 @@ namespace RuntimeInspectorNamespace
 			( (RectTransform) invokeButton.transform ).sizeDelta = new Vector2( -Skin.IndentAmount * Depth, 0f );
 		}
 
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			invokeButton.interactable = IsInteractable;
+		}
+
 		public void SetBoundMethod( ExposedMethod boundMethod )
 		{
 			this.boundMethod = boundMethod;

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/NumberField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/NumberField.cs
@@ -86,5 +86,12 @@ namespace RuntimeInspectorNamespace
 			if( !numberHandler.ValuesAreEqual( Value, prevVal ) )
 				input.Text = numberHandler.ToString( Value );
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			input.BackingField.interactable = IsInteractable;
+			input.BackingField.textComponent.color = this.GetTextColor();
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/NumberRangeField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/NumberRangeField.cs
@@ -71,6 +71,12 @@ namespace RuntimeInspectorNamespace
 			( (RectTransform) input.transform ).anchorMin = new Vector2( 1f - inputFieldWidth, 0f );
 		}
 
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			slider.BackingField.interactable = IsInteractable;
+		}
+
 		public override void Refresh()
 		{
 			base.Refresh();

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ObjectField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ObjectField.cs
@@ -171,5 +171,13 @@ namespace RuntimeInspectorNamespace
 				IsExpanded = true;
 			}
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			initializeObjectButton.interactable = IsInteractable;
+			Text buttonText = initializeObjectButton.GetComponentInChildren<Text>();
+			buttonText.color = this.GetTextColor();
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ObjectReferenceField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/ObjectReferenceField.cs
@@ -47,6 +47,9 @@ namespace RuntimeInspectorNamespace
 
 		private void ShowReferencePicker( PointerEventData eventData )
 		{
+			if ( !IsInteractable )
+				return;
+
 			Object[] allReferences = Resources.FindObjectsOfTypeAll( BoundVariableType );
 
 			ObjectReferencePicker.Instance.Skin = Inspector.Skin;
@@ -127,6 +130,14 @@ namespace RuntimeInspectorNamespace
 
 			if( lastValue != Value )
 				OnReferenceChanged( (Object) Value );
+		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			Color textColor = this.GetTextColor();
+			referenceNameText.color = textColor;
+			background.color *= textColor;
 		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/RectField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/RectField.cs
@@ -178,6 +178,27 @@ namespace RuntimeInspectorNamespace
 			( (RectTransform) inputH.transform ).SetAnchorMinMaxInputField( labelH.rectTransform, rightSideAnchorMin, new Vector2( rightSideAnchorMax.x, 0.5f ) );
 		}
 
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			Color textColor = this.GetTextColor();
+
+			inputX.BackingField.interactable = IsInteractable;
+			inputY.BackingField.interactable = IsInteractable;
+			inputW.BackingField.interactable = IsInteractable;
+			inputH.BackingField.interactable = IsInteractable;
+
+			inputX.BackingField.textComponent.color = textColor;
+			inputY.BackingField.textComponent.color = textColor;
+			inputW.BackingField.textComponent.color = textColor;
+			inputH.BackingField.textComponent.color = textColor;
+
+			labelX.color = textColor;
+			labelY.color = textColor;
+			labelW.color = textColor;
+			labelH.color = textColor;
+		}
+
 		public override void Refresh()
 		{
 #if UNITY_2017_2_OR_NEWER

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/StringField.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/StringField.cs
@@ -112,5 +112,12 @@ namespace RuntimeInspectorNamespace
 			else
 				input.Text = (string) Value;
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			input.BackingField.interactable = IsInteractable;
+			input.BackingField.textComponent.color = this.GetTextColor();
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector2Field.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector2Field.cs
@@ -165,5 +165,20 @@ namespace RuntimeInspectorNamespace
 					inputY.Text = val.y.ToString( RuntimeInspectorUtils.numberFormat );
 			}
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			Color textColor = this.GetTextColor();
+
+			inputX.BackingField.interactable = IsInteractable;
+			inputY.BackingField.interactable = IsInteractable;
+
+			inputX.BackingField.textComponent.color = textColor;
+			inputY.BackingField.textComponent.color = textColor;
+
+			labelX.color = textColor;
+			labelY.color = textColor;
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector3Field.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector3Field.cs
@@ -191,5 +191,23 @@ namespace RuntimeInspectorNamespace
 					inputZ.Text = val.z.ToString( RuntimeInspectorUtils.numberFormat );
 			}
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			Color textColor = this.GetTextColor();
+
+			inputX.BackingField.interactable = IsInteractable;
+			inputY.BackingField.interactable = IsInteractable;
+			inputZ.BackingField.interactable = IsInteractable;
+
+			inputX.BackingField.textComponent.color = textColor;
+			inputY.BackingField.textComponent.color = textColor;
+			inputZ.BackingField.textComponent.color = textColor;
+
+			labelX.color = textColor;
+			labelY.color = textColor;
+			labelZ.color = textColor;
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector4Field.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Fields/Vector4Field.cs
@@ -197,5 +197,26 @@ namespace RuntimeInspectorNamespace
 					inputW.Text = val.w.ToString( RuntimeInspectorUtils.numberFormat );
 			}
 		}
+
+		protected override void OnIsInteractableChanged()
+		{
+			base.OnIsInteractableChanged();
+			Color textColor = this.GetTextColor();
+
+			inputX.BackingField.interactable = IsInteractable;
+			inputY.BackingField.interactable = IsInteractable;
+			inputZ.BackingField.interactable = IsInteractable;
+			inputW.BackingField.interactable = IsInteractable;
+
+			inputX.BackingField.textComponent.color = textColor;
+			inputY.BackingField.textComponent.color = textColor;
+			inputZ.BackingField.textComponent.color = textColor;
+			inputW.BackingField.textComponent.color = textColor;
+
+			labelX.color = textColor;
+			labelY.color = textColor;
+			labelZ.color = textColor;
+			labelW.color = textColor;
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Helpers/RuntimeInspectorUtils.cs
@@ -989,5 +989,12 @@ namespace RuntimeInspectorNamespace
 
 			return null;
 		}
+
+		public static Color GetTextColor( this InspectorField drawer )
+		{
+			if( drawer.IsInteractable )
+				return drawer.Skin.TextColor;
+			return drawer.Skin.InactiveTextColor;
+		}
 	}
 }

--- a/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Skin/UISkin.cs
+++ b/Plugins/RuntimeInspector/Scripts/RuntimeInspector/Skin/UISkin.cs
@@ -159,6 +159,21 @@ namespace RuntimeInspectorNamespace
 		}
 
 		[SerializeField]
+		private Color m_inactiveTextColor = Color.gray;
+		public Color InactiveTextColor
+		{
+			get { return m_inactiveTextColor; }
+			set
+			{
+				if( m_inactiveTextColor != value )
+				{
+					m_inactiveTextColor = value;
+					m_version++;
+				}
+			}
+		}
+
+		[SerializeField]
 		private Color m_scrollbarColor = Color.black;
 		public Color ScrollbarColor
 		{


### PR DESCRIPTION
This PR adds support for read-only fields. A drawer can be made read-only from outside, for example in a `IRuntimeInspectorCustomEditor`, or via the new `RuntimeInspectorReadonlyAttribute`. This attribute can specify a static function, which is queried in `InspectorField.Refresh()` and returns whether the corresponding field or property should be rendered as read-only. If no function is supplied, members with this attribute are always considered read-only.

Of course it would be nice to also link instance methods in the attribute, but this would necessitate further code changes, because:
1. C# doesn't allow delegates to be passed to attribute constructors, which only leaves reflection as alternative to find the method.
2. Code that has access to the `MemberInfo` (`InspectorField.BindTo()`) to get the attribute from, doesn't have access to the instance on which to search for the method.

Let me know what you think about this implementation. If you are open for a merge, I'm happy to supply documentation.